### PR TITLE
Additional services log to journal

### DIFF
--- a/setup/containers/journal_logger_postsetup
+++ b/setup/containers/journal_logger_postsetup
@@ -35,6 +35,16 @@ for CONTAINER in $CONTAINERS; do
       echo "postgres detected."
       lxc exec $container_name -- sh -c "echo \"log_destination = 'syslog'\" >> /etc/postgresql/13/main/postgresql.conf"
       lxc exec $container_name -- service postgresql restart
+    elif [[ "$container_type" == "munin_monitor" ]]; then
+      echo "munin detected."
+      lxc exec $container_name -- sed -i '/ErrorLog/s/.*/ErrorLog syslog/' /etc/apache2/sites-enabled/000-default.conf
+      lxc exec $container_name -- sed -i '/CustomLog/s/.*/CustomLog \"| \/usr\/bin\/logger -t munin -p user.info\" combined/' /etc/apache2/sites-enabled/000-default.conf
+      lxc exec $container_name -- service apache2 restart
+    fi
+
+    if [ "$(lxc exec $container_name -- dpkg -l | grep munin-node)" ]; then
+      lxc exec $container_name -- sed -i '/log_file/s/.*/log_file Sys::Syslog/' /etc/munin/munin-node.conf
+      lxc exec $container_name -- service munin-node restart
     fi
 
     lxc exec $container_name -- apt install -y systemd-journal-remote

--- a/setup/containers/journal_logger_postsetup
+++ b/setup/containers/journal_logger_postsetup
@@ -16,7 +16,19 @@ for CONTAINER in $CONTAINERS; do
       continue
     fi
 
-    echo "[INFO] Configuring remote logging for $container_name"
+    echo -n "[INFO] Configuring remote logging for $container_name.."
+    if [[ "$container_type" == "nginx_proxy" ]]; then
+      echo "nginx detected."
+      lxc exec $container_name -- sed -i '/error_log/s/.*/error_log syslog:server=unix:\/dev\/log info;/' /etc/nginx/nginx.conf
+      lxc exec $container_name -- sed -i '/http {/a  access_log   syslog:server=unix:\/dev\/log;' /etc/nginx/nginx.conf
+      lxc exec $container_name -- service nginx restart
+    elif [[ "$container_type" == "apache_proxy" ]]; then
+      echo "apache2 detected."
+      lxc exec $container_name -- sed -i '/ErrorLog/s/.*/ErrorLog syslog/' /etc/apache2/sites-enabled/000-default.conf
+      lxc exec $container_name -- sed -i '/CustomLog/s/.*/CustomLog \"| \/usr\/bin\/logger -t apache2 -p user.info\" combined/' /etc/apache2/sites-enabled/000-default.conf
+      lxc exec $container_name -- service apache2 restart
+    fi
+
     lxc exec $container_name -- apt install -y systemd-journal-remote
     lxc exec $container_name -- sh -c "echo URL=http://$IP:19532 >> /etc/systemd/journal-upload.conf"
     lxc exec $container_name -- adduser --system --home /run/systemd --no-create-home --disabled-login --group systemd-journal-upload

--- a/setup/containers/journal_logger_postsetup
+++ b/setup/containers/journal_logger_postsetup
@@ -1,5 +1,9 @@
+LOGS_DIR=$(echo $CONTAINER | jq -r .directory)
+LOGS_BACKEND=$(echo $CONTAINER | jq -r .storage)
+
 S3_STORAGE_CLASS="STANDARD_IA"
 CONTAINER_LOGS_DIR="/var/log/journal/remote"
+
 POOL_NAME="logs"
 VOLUME_NAME="logs"
 

--- a/setup/containers/journal_logger_postsetup
+++ b/setup/containers/journal_logger_postsetup
@@ -56,7 +56,7 @@ if [[ $LOGS_BACKEND == fs ]]; then
   fi
 
   echo -n "Creating storage volume $VOLUME_NAME..."
-  volume_exist=$(lxc storage volume list $POOL_NAME | grep $VOLUME_NAME)
+  volume_exist=$(lxc storage volume list $POOL_NAME | grep -w $VOLUME_NAME)
   if ! [ "$volume_exist" ]; then
     lxc storage volume create $POOL_NAME $VOLUME_NAME
     echo "created"

--- a/setup/containers/journal_logger_postsetup
+++ b/setup/containers/journal_logger_postsetup
@@ -31,6 +31,10 @@ for CONTAINER in $CONTAINERS; do
       lxc exec $container_name -- sed -i '/ErrorLog/s/.*/ErrorLog syslog/' /etc/apache2/sites-enabled/000-default.conf
       lxc exec $container_name -- sed -i '/CustomLog/s/.*/CustomLog \"| \/usr\/bin\/logger -t apache2 -p user.info\" combined/' /etc/apache2/sites-enabled/000-default.conf
       lxc exec $container_name -- service apache2 restart
+    elif [[ "$container_type" == "postgres" ]]; then
+      echo "postgres detected."
+      lxc exec $container_name -- sh -c "echo \"log_destination = 'syslog'\" >> /etc/postgresql/13/main/postgresql.conf"
+      lxc exec $container_name -- service postgresql restart
     fi
 
     lxc exec $container_name -- apt install -y systemd-journal-remote

--- a/setup/create_containers.sh
+++ b/setup/create_containers.sh
@@ -87,11 +87,6 @@ for CONTAINER in $CONTAINERS; do
 	lxc exec $NAME -- service munin-node restart
   fi
 
-  if [[ $TYPE == journal_logger ]]; then
-    LOGS_DIR=$(echo $CONTAINER | jq -r .directory)
-    LOGS_BACKEND=$(echo $CONTAINER | jq -r .storage)
-  fi
-
   # source any post setup scripts
   if [[ -f containers/${TYPE}_postsetup ]]; 
   then

--- a/setup/service/dhis2-create-instance
+++ b/setup/service/dhis2-create-instance
@@ -316,7 +316,7 @@ if [ "$logger_present" ]; then
     # lxc exec $NAME -- chown systemd-journal-upload /var/lib/private/systemd/
     lxc exec $NAME -- sed -i -e 's/DynamicUser\=yes/DynamicUser\=no/' /lib/systemd/system/systemd-journal-upload.service
     lxc exec $NAME -- systemctl daemon-reload
-    lxc exec $NAME-- systemctl enable systemd-journal-upload.service
-    lxc exec $NAME-- service systemd-journal-upload start
+    lxc exec $NAME -- systemctl enable systemd-journal-upload.service
+    lxc exec $NAME -- service systemd-journal-upload start
   fi
 fi


### PR DESCRIPTION
This PR configures additional services to log directly into the journal.

This includes:
- nginx and apache2 for proxy
- postgresql
- munin for monitor and munin-node for all instances where it's present.